### PR TITLE
Fix compilation error for structured binding

### DIFF
--- a/code/2/2.05.structured.binding.cpp
+++ b/code/2/2.05.structured.binding.cpp
@@ -7,6 +7,7 @@
 //
 
 #include <iostream>
+#include <tuple>
 #include <string>
 
 std::tuple<int, double, std::string> f() {


### PR DESCRIPTION
The header  <tuple> is missing. After adding it, it compiles fine with clang in c++17 mode.