### PR TITLE
 Print out the stored_value1 and stored_value2 for the lambda example.

### DIFF
--- a/code/2/2.05.structured.binding.cpp
+++ b/code/2/2.05.structured.binding.cpp
@@ -7,6 +7,7 @@
 //
 
 #include <iostream>
+#include <tuple>
 #include <string>
 
 std::tuple<int, double, std::string> f() {

--- a/code/3/3.1.cpp
+++ b/code/3/3.1.cpp
@@ -16,6 +16,7 @@ void learn_lambda_func_1() {
     };
     value_1 = 100;
     auto stored_value_1 = copy_value_1();
+    std::cout << "stored_value_1=" << stored_value_1 << std::endl;
     // 这时, stored_value_1 == 1, 而 value_1 == 100.
     // 因为 copy_value_1 在创建时就保存了一份 value_1 的拷贝
 }
@@ -27,6 +28,7 @@ void learn_lambda_func_2() {
     };
     value_2 = 100;
     auto stored_value_2 = copy_value_2();
+    std::cout << "stored_value_2=" << stored_value_2 << std::endl;
     // 这时, stored_value_2 == 100, value_1 == 100.
     // 因为 copy_value_2 保存的是引用
 }


### PR DESCRIPTION
To make it eaiser for the readers to understand the difference
between lambda capture by value and by reference.