### PR TITLE
Update 03-runtime.md

### DIFF
--- a/book/zh-cn/03-runtime.md
+++ b/book/zh-cn/03-runtime.md
@@ -236,7 +236,7 @@ void reference(std::string&& str) {
 int main()
 {
     std::string lv1 = "string,"; // lv1 是一个左值
-    // std::string&& r1 = s1; // 非法, 右值引用不能引用左值
+    // std::string&& r1 = lv1; // 非法, 右值引用不能引用左值
     std::string&& rv1 = std::move(lv1); // 合法, std::move可以将左值转移为右值
     std::cout << rv1 << std::endl; // string,
 


### PR DESCRIPTION
在[右值引用和左值引用](https://github.com/changkun/modern-cpp-tutorial/blob/master/book/zh-cn/03-runtime.md#%E5%8F%B3%E5%80%BC%E5%BC%95%E7%94%A8%E5%92%8C%E5%B7%A6%E5%80%BC%E5%BC%95%E7%94%A8)部分
```main```函数里面第二行的注释
```c++
// std::string&& r1 = s1; // 非法, 右值引用不能引用左值
```
s1并未在上下文出现，应该这里是指上面所写的lv1