### PR TITLE
Fix the wrong about delctype

### DIFF
--- a/book/en-us/02-usability.md
+++ b/book/en-us/02-usability.md
@@ -435,7 +435,7 @@ auto arr = new auto(10); // arr as int *
 ### decltype
 
 The `decltype` keyword is used to solve the defect that the auto keyword 
-can only type the variable. Its usage is very similar to `sizeof`:
+can only type the variable. Its usage is very similar to `typeof`:
 
 
 ```cpp

--- a/book/zh-cn/02-usability.md
+++ b/book/zh-cn/02-usability.md
@@ -369,7 +369,7 @@ auto arr = new auto(10); // arr 被推导为 int *
 
 ### decltype
 
-`decltype` 关键字是为了解决 auto 关键字只能对变量进行类型推导的缺陷而出现的。它的用法和 `sizeof` 很相似：
+`decltype` 关键字是为了解决 auto 关键字只能对变量进行类型推导的缺陷而出现的。它的用法和 `typeof` 很相似：
 
 ```cpp
 decltype(表达式)


### PR DESCRIPTION
decltype应当与typeof更相似,而非sizeof

## 变化箱单

- 解决了关于 decltype 的描述性错误 (包括中文与英文版本)

## 参考文献

无

