### PR TITLE
book/en: fix typos

### DIFF
--- a/book/en-us/02-usability.md
+++ b/book/en-us/02-usability.md
@@ -23,7 +23,7 @@ traditional C++ treats `NULL` and `0` as the same thing,
 depending on how the compiler defines NULL, 
 and some compilers define NULL as `((void*)0)` Some will define it directly as `0`.
 
-C++ ** does not allow ** to implicitly convert `void *` to other types. 
+C++ **does not allow** to implicitly convert `void *` to other types. 
 But if the compiler tries to define `NULL` as `((void*)0)`, then in the following code:
 
 ```cpp


### PR DESCRIPTION
## 实际描述

- 文件路径：book/en-us/02-usability.md
- 原文段落：

```
## 2.1 Constants

### nullptr

The purpose of `nullptr` appears to replace `NULL`. In a sense, 
traditional C++ treats `NULL` and `0` as the same thing, 
depending on how the compiler defines NULL, 
and some compilers define NULL as `((void*)0)` Some will define it directly as `0`.

C++ ** does not allow ** to implicitly convert `void *` to other types. 
But if the compiler tries to define `NULL` as `((void*)0)`, then in the following code:

```

## 预期描述

```
## 2.1 Constants

### nullptr

The purpose of `nullptr` appears to replace `NULL`. In a sense, 
traditional C++ treats `NULL` and `0` as the same thing, 
depending on how the compiler defines NULL, 
and some compilers define NULL as `((void*)0)` Some will define it directly as `0`.

C++ **does not allow** to implicitly convert `void *` to other types. 
But if the compiler tries to define `NULL` as `((void*)0)`, then in the following code:

```

## 附图

![image](https://user-images.githubusercontent.com/7806458/91510949-1d173f00-e911-11ea-9884-11ee8a162a16.png)
