### PR TITLE
Remove ch2 - default template parameters

### DIFF
--- a/book/en-us/02-usability.md
+++ b/book/en-us/02-usability.md
@@ -709,28 +709,6 @@ int main() {
 }
 ```
 
-### Default template parameters
-
-We may have defined an addition function:
-
-```cpp
-template<typename T, typename U>
-auto add(T x, U y) -> decltype(x+y) {
-    return x+y;
-}
-```
-
-However, when used, it is found that to use add, you must specify the type of its template parameters each time.
-
-A convenience is provided in C++11 to specify the default parameters of the template:
-
-```cpp
-template<typename T = int, typename U = int>
-auto add(T x, U y) -> decltype(x+y) {
-    return x+y;
-}
-```
-
 ### Variadic templates
 
 The template has always been one of C++'s unique **Black Magic**.

--- a/book/zh-cn/02-usability.md
+++ b/book/zh-cn/02-usability.md
@@ -619,35 +619,6 @@ int main() {
 }
 ```
 
-### 默认模板参数
-
-我们可能定义了一个加法函数：
-
-```cpp
-// c++11 version
-template<typename T, typename U>
-auto add(T x, U y) -> decltype(x+y) {
-    return x+y;
-}
-
-// Call add function
-auto ret = add<int, int>(1,3);
-```
-
-但在使用时发现，要使用 `add`，就必须每次都指定其模板参数的类型。
-
-在 C++11 中提供了一种便利，可以指定模板的默认参数：
-
-```cpp
-template<typename T = int, typename U = int>
-auto add(T x, U y) -> decltype(x+y) {
-    return x+y;
-}
-
-// Call add function
-auto ret = add(1,3);
-```
-
 ### 变长参数模板
 
 模板一直是 C++ 所独有的**黑魔法**（一起念：**Dark Magic**）之一。


### PR DESCRIPTION
## Description

The example of this section is incorrect. It is totally OK to just write `add(1, 3)` without default parameters even in C++98, since the compiler will deduce the type.

What's more, this feature is even not a C++11 feature. So I just delete it.

## Change List

As the title shows

## Reference

https://en.cppreference.com/w/cpp/language/template_parameters

https://en.cppreference.com/w/cpp/language/template_argument_deduction
