### PR TITLE
Fix a typo in section 9.2

### DIFF
--- a/book/zh-cn/09-others.md
+++ b/book/zh-cn/09-others.md
@@ -72,7 +72,7 @@ int main()
 try {
     may_throw();
 } catch (...) {
-    std::cout << "捕获异常, 来自 my_throw()" << std::endl;
+    std::cout << "捕获异常, 来自 may_throw()" << std::endl;
 }
 try {
     non_block_throw();

--- a/book/zh-cn/09-others.md
+++ b/book/zh-cn/09-others.md
@@ -89,7 +89,7 @@ try {
 最终输出为：
 
 ```
-捕获异常, 来自 my_throw()
+捕获异常, 来自 may_throw()
 捕获异常, 来自 non_block_throw()
 ```
 


### PR DESCRIPTION
<!-- English Version -->

## Fix a typo in section 9.2

Section 9.2 noexcept: my_throw() -> may_throw()

## Change List

- Fix a typo in section 9.2
- my_throw() -> may_throw()

## Reference

none

---

<!-- 中文版 -->

## 改正9.2节一个拼写错误

第9.2节noexcept：my_throw() -> may_throw()

## 变化箱单

- 改正一个9.2节的拼写错误
- my_throw() -> may_throw()

## 参考文献

无

### 注

第192行代码的的变动是无意造成的，并未修改任何内容