### PR TITLE
book: re-compose words to avoid out of pdf's margin

### DIFF
--- a/book/en-us/04-containers.md
+++ b/book/en-us/04-containers.md
@@ -118,7 +118,7 @@ And select the appropriate location to insert into the container. When traversin
 The elements in the unordered container are not sorted, and the internals is implemented by the Hash table. The average complexity of inserting and searching for elements is `O(constant)`,
 Significant performance gains can be achieved without concern for the order of the elements inside the container.
 
-C++11 introduces two sets of unordered containers: `std::unordered_map`/`std::unordered_multimap` and
+C++11 introduces two unordered containers: `std::unordered_map`/`std::unordered_multimap` and
 `std::unordered_set`/`std::unordered_multiset`.
 
 Their usage is basically similar to the original `std::map`/`std::multimap`/`std::set`/`set::multiset`

--- a/book/zh-cn/04-containers.md
+++ b/book/zh-cn/04-containers.md
@@ -115,7 +115,7 @@ std::sort(arr.begin(), arr.end());
 而无序容器中的元素是不进行排序的，内部通过 Hash 表实现，插入和搜索元素的平均复杂度为 `O(constant)`，
 在不关心容器内部元素顺序时，能够获得显著的性能提升。
 
-C++11 引入了两组无序容器：`std::unordered_map`/`std::unordered_multimap` 和 
+C++11 引入了的两组无序容器分别是：`std::unordered_map`/`std::unordered_multimap` 和 
 `std::unordered_set`/`std::unordered_multiset`。
 
 它们的用法和原有的 `std::map`/`std::multimap`/`std::set`/`set::multiset` 基本类似，


### PR DESCRIPTION
resolve #issue_id

<!-- English Version -->

## Description

Re-compose words to avoid words out of compiled pdf's margin. 

## Change List
Before:
<img width="661" alt="en-us-before" src="https://user-images.githubusercontent.com/59325440/156190895-0de3979f-7a0f-4c53-ae70-7994439370f7.png">

After:
<img width="661" alt="en-us-after" src="https://user-images.githubusercontent.com/59325440/156190811-982bd9f8-d5b7-4f64-94d9-a7abcf9b4cc6.png">

---

<!-- 中文版 -->

## 说明

重新组织句子结构使编译后的 PDF 排版字符不超出边缘。

## 变化箱单
之前：
<img width="661" alt="zh-cn-before" src="https://user-images.githubusercontent.com/59325440/156190938-3615e997-7684-4670-804b-594a582fb567.png">
之后：
<img width="661" alt="zh-cn-after" src="https://user-images.githubusercontent.com/59325440/156190968-102b40a1-9ae1-4953-b8db-6926f713c988.png">

