### PR TITLE
fix: correct errors in string literal explanation

### DIFF
--- a/book/en-us/03-runtime.md
+++ b/book/en-us/03-runtime.md
@@ -263,20 +263,24 @@ Temporary variables returned by non-references, temporary variables generated
 by operation expressions, original literals, and Lambda expressions
 are all pure rvalue values.
 
-Note that a string literal became rvalue in a class, and remains an lvalue in other cases (e.g., in a function)：
+Note that a literal (except a string literal) is a prvalue. But a string literal is an lvalue with type `const char` array. As follows:
 
 ```cpp
-class Foo {
-        const char*&& right = "this is a rvalue";
-public:
-        void bar() {
-            right = "still rvalue"; // the string literal is a rvalue
-        }
-};
+#include <type_traits>
 
 int main() {
-    const char* const &left = "this is an lvalue"; // the string literal is an lvalue
+    const char (&left)[6] = "01234";      // Right, the type of "01234" is const char [6], so it is an lvalue
+    static_assert(std::is_same<decltype("01234"), const char(&)[6]>::value, ""); // Assert success. It is a const char [6] indeed. Note that decltype(expr) yields lvalue reference if expr is an lvalue and neither an unparenthesized id-expression nor an unparenthesized class member access expression
+    // const char (&&right)[6] = "01234"; // Error, "01234" is an lvalue, which cannot be referenced by an rvalue reference
 }
+```
+
+However, an array can be implicitly converted to a corresponding pointer.The result, if not an lvalue reference, is an rvalue (xvalue if the result is an rvalue reference, prvalue otherwise). As follows:
+
+```cpp
+const char* p = "01234";      // Right, "01234" is implicitly converted to const char*
+const char*&& pr = "01234";   // Right, "01234" is implicitly converted to const char*, which is a prvalue.
+// const char*& pl = "01234"; // Error, no lvalue of type const char*!
 ```
 
 **xvalue, expiring value** is the concept proposed by C++11 to introduce

--- a/book/en-us/03-runtime.md
+++ b/book/en-us/03-runtime.md
@@ -263,24 +263,32 @@ Temporary variables returned by non-references, temporary variables generated
 by operation expressions, original literals, and Lambda expressions
 are all pure rvalue values.
 
-Note that a literal (except a string literal) is a prvalue. But a string literal is an lvalue with type `const char` array. As follows:
+Note that a literal (except a string literal) is a prvalue. However, a string
+literal is an lvalue with type `const char` array. Consider the following examples:
 
 ```cpp
 #include <type_traits>
 
 int main() {
-    const char (&left)[6] = "01234";      // Right, the type of "01234" is const char [6], so it is an lvalue
-    static_assert(std::is_same<decltype("01234"), const char(&)[6]>::value, ""); // Assert success. It is a const char [6] indeed. Note that decltype(expr) yields lvalue reference if expr is an lvalue and neither an unparenthesized id-expression nor an unparenthesized class member access expression
-    // const char (&&right)[6] = "01234"; // Error, "01234" is an lvalue, which cannot be referenced by an rvalue reference
+    // Correct. The type of "01234" is const char [6], so it is an lvalue
+    const char (&left)[6] = "01234";
+
+    // Assert success. It is a const char [6] indeed. Note that decltype(expr)
+    // yields lvalue reference if expr is an lvalue and neither an unparenthesized
+    // id-expression nor an unparenthesized class member access expression.
+    static_assert(std::is_same<decltype("01234"), const char(&)[6]>::value, "");
+
+    // Error. "01234" is an lvalue, which cannot be referenced by an rvalue reference
+    // const char (&&right)[6] = "01234";
 }
 ```
 
-However, an array can be implicitly converted to a corresponding pointer.The result, if not an lvalue reference, is an rvalue (xvalue if the result is an rvalue reference, prvalue otherwise). As follows:
+However, an array can be implicitly converted to a corresponding pointer.The result, if not an lvalue reference, is an rvalue (xvalue if the result is an rvalue reference, prvalue otherwise):
 
 ```cpp
-const char* p = "01234";      // Right, "01234" is implicitly converted to const char*
-const char*&& pr = "01234";   // Right, "01234" is implicitly converted to const char*, which is a prvalue.
-// const char*& pl = "01234"; // Error, no lvalue of type const char*!
+const char*   p    = "01234"; // Correct. "01234" is implicitly converted to const char*
+const char*&& pr   = "01234"; // Correct. "01234" is implicitly converted to const char*, which is a prvalue.
+// const char*& pl = "01234"; // Error. There is no type const char* lvalue
 ```
 
 **xvalue, expiring value** is the concept proposed by C++11 to introduce

--- a/book/zh-cn/03-runtime.md
+++ b/book/zh-cn/03-runtime.md
@@ -231,7 +231,7 @@ int main() {
 
 int main() {
     const char (&left)[6] = "01234";      // 正确，"01234" 类型为 const char [6]，因此是左值
-    static_assert(std::is_same<decltype("01234"), const char(&)[6]>::value, ""); // 断言正确，确实是 const char [6] 类型，注意 decltype(expr) 在 expr 是左值且非 id 表达式与类成员表达式时，会返回左值引用
+    static_assert(std::is_same<decltype("01234"), const char(&)[6]>::value, ""); // 断言正确，确实是 const char [6] 类型，注意 decltype(expr) 在 expr 是左值且非无括号包裹的 id 表达式与类成员表达式时，会返回左值引用
     // const char (&&right)[6] = "01234"; // 错误，"01234" 是左值，不可被右值引用
 }
 ```

--- a/book/zh-cn/03-runtime.md
+++ b/book/zh-cn/03-runtime.md
@@ -230,18 +230,24 @@ int main() {
 #include <type_traits>
 
 int main() {
-    const char (&left)[6] = "01234";      // 正确，"01234" 类型为 const char [6]，因此是左值
-    static_assert(std::is_same<decltype("01234"), const char(&)[6]>::value, ""); // 断言正确，确实是 const char [6] 类型，注意 decltype(expr) 在 expr 是左值且非无括号包裹的 id 表达式与类成员表达式时，会返回左值引用
-    // const char (&&right)[6] = "01234"; // 错误，"01234" 是左值，不可被右值引用
+    // 正确，"01234" 类型为 const char [6]，因此是左值
+    const char (&left)[6] = "01234";
+
+    // 断言正确，确实是 const char [6] 类型，注意 decltype(expr) 在 expr 是左值
+    // 且非无括号包裹的 id 表达式与类成员表达式时，会返回左值引用
+    static_assert(std::is_same<decltype("01234"), const char(&)[6]>::value, "");
+
+    // 错误，"01234" 是左值，不可被右值引用
+    // const char (&&right)[6] = "01234";
 }
 ```
 
 但是注意，数组可以被隐式转换成相对应的指针类型，而转换表达式的结果（如果不是左值引用）则一定是个右值（右值引用为将亡值，否则为纯右值）。例如：
 
 ```cpp
-const char* p = "01234";       // 正确，"01234" 被隐式转换为 const char*
-const char*&& pr = "01234";    // 正确，"01234" 被隐式转换为 const char*，该转换的结果是纯右值
-// const char*& pl = "01234";  // 错误，此处不存在 const char* 类型的左值
+const char*   p   = "01234";  // 正确，"01234" 被隐式转换为 const char*
+const char*&& pr  = "01234";  // 正确，"01234" 被隐式转换为 const char*，该转换的结果是纯右值
+// const char*& pl = "01234"; // 错误，此处不存在 const char* 类型的左值
 ```
 
 **将亡值(xvalue, expiring value)**，是 C++11 为了引入右值引用而提出的概念（因此在传统 C++ 中，


### PR DESCRIPTION
<!-- English Version -->

## Description

The previous statement about string literal is incorrect. [According to cppreference](https://en.cppreference.com/w/cpp/language/value_category#lvalue), a string literal is an lvalue forever, [which is an array of `const char`](https://en.cppreference.com/w/cpp/language/string_literal).

## Change List

- Fix the statement about string literal in 03-runtime.md

## Reference

+ https://en.cppreference.com/w/cpp/language/value_category#lvalue
+ https://en.cppreference.com/w/cpp/language/string_literal
+ https://eel.is/c++draft/expr.prim#literal

---

<!-- 中文版 -->

## 说明

原来对于“字符串字面量在类中是右值”的叙述有误。根据 [cppreference 对于左值的表述](https://zh.cppreference.com/w/cpp/language/value_category#.E5.B7.A6.E5.80.BC)，字符串字面量永远是一个左值，[其类型是 `const char` 数组](https://zh.cppreference.com/w/cpp/language/string_literal)。

## 变化箱单

- 修复了 03-runtime.md 中关于字符串字面量的表述

## 参考文献

+ https://zh.cppreference.com/w/cpp/language/value_category#.E5.B7.A6.E5.80.BC
+ https://zh.cppreference.com/w/cpp/language/string_literal
+ https://eel.is/c++draft/expr.prim#literal