### PR TITLE
book: fix variable name: s1 → lv1

### DIFF
--- a/book/en-us/03-runtime.md
+++ b/book/en-us/03-runtime.md
@@ -339,7 +339,7 @@ void reference(std::string&& str) {
 int main()
 {
     std::string  lv1 = "string,";       // lv1 is a lvalue
-    // std::string&& r1 = s1;           // illegal, rvalue can't ref to lvalue
+    // std::string&& r1 = lv1;          // illegal, rvalue can't ref to lvalue
     std::string&& rv1 = std::move(lv1); // legal, std::move can convert lvalue to rvalue
     std::cout << rv1 << std::endl;      // string,
 


### PR DESCRIPTION
• s1 is not defined/declared anywhere
• lv1 is actually used

<!-- English Version -->

## Description

The variable s1 is undefined in this example. I am sure lv1 is meant.

## Change List

- Fix variable name