### PR TITLE
book: “non-linear” should be “non-constant”

### DIFF
--- a/book/en-us/03-runtime.md
+++ b/book/en-us/03-runtime.md
@@ -374,7 +374,7 @@ int main() {
 }
 ```
 
-The first question, why not allow non-linear references to bind to non-lvalues?
+The first question, why not allow non-constant references to bind to non-lvalues?
 This is because there is a logic error in this approach:
 
 ```cpp


### PR DESCRIPTION
## Description

There is no notion of linearity in this book. However, the context makes it clear that non-constant values are meant. So let us fix that.

## Change List

- Use adjective non-constant; not non-linear