### PR TITLE
fix: typo error of 2.3

### DIFF
--- a/book/en-us/02-usability.md
+++ b/book/en-us/02-usability.md
@@ -378,8 +378,8 @@ One of the most common and notable examples of type derivation using `auto` is t
 ```cpp
 // before C++11
 // cbegin() returns vector<int>::const_iterator
-// and therefore itr is type vector<int>::const_iterator
-for(vector<int>::const_iterator it = vec.cbegin(); itr != vec.cend(); ++it)
+// and therefore it is type vector<int>::const_iterator
+for(vector<int>::const_iterator it = vec.cbegin(); it != vec.cend(); ++it)
 ```
 
 When we have `auto`:

--- a/book/zh-cn/02-usability.md
+++ b/book/zh-cn/02-usability.md
@@ -314,8 +314,8 @@ C++11 引入了 `auto` 和 `decltype` 这两个关键字实现了类型推导，
 ```cpp
 // 在 C++11 之前
 // 由于 cbegin() 将返回 vector<int>::const_iterator
-// 所以 itr 也应该是 vector<int>::const_iterator 类型
-for(vector<int>::const_iterator it = vec.cbegin(); itr != vec.cend(); ++it)
+// 所以 it 也应该是 vector<int>::const_iterator 类型
+for(vector<int>::const_iterator it = vec.cbegin(); it != vec.cend(); ++it)
 ```
 
 而有了 `auto` 之后可以：


### PR DESCRIPTION
## Description

Fix typo error

## Change List

- Fix typo error of 2.3 type inference: itr -> it

## 说明

修正typo错误

## 变化箱单

- 修复了2.3 类型推导的 typo 错误：itr -> it
